### PR TITLE
Add x402-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Uses HTTP 402 "Payment Required" for instant stablecoin payments over HTTP. Buil
 - [x402 Specification](https://github.com/coinbase/x402/tree/main/specs) - Full technical specification.
 - [x402 Coinbase Documentation](https://docs.cdp.coinbase.com/x402/welcome) - Developer docs and quickstart.
 - [x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) - Solana integration guide.
+- [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs. CLI that auto-pays HTTP 402 responses with USDC on Base and Solana, with MCP stdio proxy for AI agents.
 
 ### L402
 


### PR DESCRIPTION
Adds x402-proxy to the x402 section under Crypto payment rails.

**x402-proxy** is `curl` for x402 paid APIs - a CLI that auto-pays HTTP 402 responses with USDC on Base and Solana, with an MCP stdio proxy for AI agents.

Open-source, published on npm as [`x402-proxy`](https://www.npmjs.com/package/x402-proxy). Source: [cascade-protocol/x402-proxy](https://github.com/cascade-protocol/x402-proxy).