### PR TITLE
Add Onyx Actions paid MCP + framework under x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Uses HTTP 402 "Payment Required" for instant stablecoin payments over HTTP. Buil
 - [x402 Specification](https://github.com/coinbase/x402/tree/main/specs) - Full technical specification.
 - [x402 Coinbase Documentation](https://docs.cdp.coinbase.com/x402/welcome) - Developer docs and quickstart.
 - [x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) - Solana integration guide.
+- [Onyx Actions](https://onyx-actions.onrender.com) - Reference paid MCP server with 33 agent endpoints across Base + Solana on-chain primitives (tx_explainer, token_risk_scan, jupiter_quote, wallet_activity), captcha OCR, browser automation, and web utility. USDC settlement via x402, no API keys.
+- [onyx-paid-mcp Framework](https://github.com/dimitrilaouanis-tech/onyx-mcp) - Open-source Python framework (FastAPI + x402 middleware) for shipping any paid MCP server. Auto-generated 402 challenges, Streamable HTTP MCP at /mcp/, Bazaar-spec manifest at /.well-known/x402.json.
 
 ### L402
 


### PR DESCRIPTION
Adds two entries under the **x402** section pointing to a reference paid MCP implementation and the underlying open-source framework:

**Onyx Actions** is a live paid-MCP server with 33 agent endpoints across Base + Solana on-chain primitives (`tx_explainer`, `token_risk_scan`, `jupiter_quote`, `wallet_activity`, etc.), captcha OCR, browser automation, and web/DNS/email utility. Settlement is x402 + USDC on Base, no API keys, no signup. Manifest: https://onyx-actions.onrender.com/.well-known/x402.json

**onyx-paid-mcp** is the open-source FastAPI + x402 middleware framework powering it. MIT licensed, on PyPI, ~5 lines stand up your own paid MCP. Repo: https://github.com/dimitrilaouanis-tech/onyx-mcp

Both fit under x402 since they're concrete adopters of the rail described in the existing section. Happy to adjust placement / wording / scope.