### PR TITLE
Add Divigent under new "Agent treasury & wallet readiness" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Maintained by [Bitrefill](https://www.bitrefill.com). Contributions welcome.
   - [x402](#x402)
   - [L402](#l402)
   - [Fewsats](#fewsats)
+- [Agent treasury & wallet readiness](#agent-treasury--wallet-readiness)
+  - [Divigent](#divigent)
 - [Fiat payment rails](#fiat-payment-rails)
   - [Stripe](#stripe)
   - [Visa](#visa)
@@ -103,6 +105,20 @@ Practical toolkit for AI agents to make L402 payments. MCP server, CLI, and Pyth
 
 - [Fewsats MCP Server](https://github.com/fewsats/fewsats-mcp) - MCP server for AI agent payments.
 - [Fewsats Python SDK](https://github.com/Fewsats/L402-python) - L402 payments for AI agents.
+
+## Agent treasury & wallet readiness
+
+Infrastructure between policy decisions and payment execution. Policy platforms decide whether an agent *may* pay; these layers make sure the wallet actually *can* pay — by assessing liquidity, maintaining reserves, and recalling from yield positions before a spend fires.
+
+### Divigent
+
+Payment-ready treasury for agent wallets on Base mainnet. Brings treasury intelligence to funded wallets: assesses liquidity before payment, maintains adaptive reserves (ML-forecast per agent's spend behavior), recalls before spend, and deploys only excess USDC into monitored venues (Aave V3 + Steakhouse USDC Prime MetaMorpho). Sits between Policy and x402 in the agentic stack. Oak Security audited; live on Base.
+
+- [Divigent](https://divigent.ai) - Main site and overview.
+- [Divigent Documentation](https://divigent.gitbook.io/divigent-docs) - SDK + protocol docs.
+- [Divigent SDK](https://github.com/Divigent/divigent-sdk) - TypeScript SDK; `npm install @divigent/sdk`.
+- [Divigent MCP Server](https://github.com/Divigent/divigent-mcp) - Model Context Protocol server.
+- [Divigent Protocol](https://github.com/Divigent/divigent-protocol) - Smart contracts and audit.
 
 ## Fiat payment rails
 


### PR DESCRIPTION
## What
Adds **Divigent** to the list under a new section: **Agent treasury & wallet readiness**.

## Why a new section
Divigent isn't a payment rail itself — it's the layer between *policy* and *payment* that ensures a funded agent wallet stays liquid for spend. The current categories (Commerce protocols / Crypto rails / Fiat rails / Ecosystem) don't cleanly capture treasury-readiness infrastructure. I'm proposing a new section, but **happy to slot it under "Ecosystem"** if you'd rather keep the list flatter — let me know.

## What Divigent is
Payment-ready treasury for agent wallets on Base mainnet. Assesses liquidity before payment, maintains adaptive reserves (ML-forecast per agent), recalls liquidity from yield venues before a spend fires, and deploys only excess USDC into monitored venues (Aave V3 + Steakhouse USDC Prime MetaMorpho). Live on Base, Oak Security audited.

Tagline that's been useful: *"Policy platforms decide whether an agent may pay. Divigent makes sure the wallet can pay."*

## Resources added
- divigent.ai
- GitBook docs
- TypeScript SDK (npm: `@divigent/sdk`)
- MCP server
- Protocol contracts + audit

## Why this is in scope
Per the list's framing ("protocols, specs, SDKs, and tools powering the emerging agentic commerce stack"), treasury infrastructure for agent wallets is increasingly load-bearing as agents shift from one-off calls to sustained operational spend — without it, a wallet with a valid policy can still fail payments because its USDC is locked in a yield venue.

Happy to iterate on phrasing or placement.