### PR TITLE
feat: add Privacy & Compliance section with TrustBoost PII Sanitizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ Bitrefill maintains this list and provides agentic commerce tooling: an eCommerc
 - [Bitrefill Agents](https://github.com/bitrefill/agents) - Agent skills for shopping on Bitrefill (bitrefill-website, bitrefill-cli).
 - [Bitrefill CLI](https://github.com/bitrefill/cli) - Command-line client. Browse, buy, and manage gift cards, top-ups, and eSIMs.
 
+## Privacy & Compliance
+
+As agentic commerce scales, the payloads agents send and receive increasingly contain personally identifiable information (PII) — names, emails, national IDs, financial identifiers, and credentials. A privacy layer before the payment or LLM call is becoming a compliance requirement, not an afterthought.
+
+### PII Sanitization
+
+- [TrustBoost PII Sanitizer](https://github.com/teodorofodocrispin-cmyk/TrustBoost-PII-Sanitizer) — Open-source, x402-native PII sanitization layer for agentic pipelines. Sanitizes text before it reaches LLMs or external APIs. Returns sanitized content, safety score, and risk category. Every paid sanitization anchored on Solana via Helius. Supports 8 languages including LATAM identifiers (RFC, CUIT, CPF). EU AI Act compliant. Try free: `tx_hash=TRIAL`.
+
 ## Further reading
 
 - [MCP, A2A, ACP, ANP Survey Paper](https://arxiv.org/html/2505.02279v1) - Academic comparison of all major agent protocols.


### PR DESCRIPTION
## What this adds

A new `Privacy & Compliance` section to the list — the first of its kind in this collection.

## Why it belongs here

As agentic commerce scales, agent payloads increasingly contain PII — names, emails, national IDs, financial identifiers. The current list covers payment protocols extensively but has no entry for the privacy layer that sits before or alongside those payments.

## Entry added

**TrustBoost PII Sanitizer** — open-source, x402-native PII sanitization for agentic pipelines. Sanitizes text before it reaches LLMs or external APIs. Proof of Sanitization anchored on Solana. 8 languages including LATAM (RFC, CUIT, CPF). EU AI Act compliant. 50 free sanitizations with tx_hash=TRIAL.

This is a genuine gap in the list — privacy and compliance are becoming mandatory infrastructure for agentic commerce, not optional add-ons.