### PR TITLE
Add TWZRD Agent Intel — live x402 MCP server on Solana

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Uses HTTP 402 "Payment Required" for instant stablecoin payments over HTTP. Buil
 - [x402 Specification](https://github.com/coinbase/x402/tree/main/specs) - Full technical specification.
 - [x402 Coinbase Documentation](https://docs.cdp.coinbase.com/x402/welcome) - Developer docs and quickstart.
 - [x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) - Solana integration guide.
+- [TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final) - Production x402 MCP server on Solana for AI agent trust scoring — free preflight checks + paid signed V5 trust receipts settled in <1s. Live endpoint: `https://intel.twzrd.xyz/mcp`
 
 ### L402
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Uses HTTP 402 "Payment Required" for instant stablecoin payments over HTTP. Buil
 - [x402 Specification](https://github.com/coinbase/x402/tree/main/specs) - Full technical specification.
 - [x402 Coinbase Documentation](https://docs.cdp.coinbase.com/x402/welcome) - Developer docs and quickstart.
 - [x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) - Solana integration guide.
-- [TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final) - Production x402 MCP server on Solana for AI agent trust scoring — free preflight checks + paid signed V5 trust receipts settled in <1s. Live endpoint: `https://intel.twzrd.xyz/mcp`
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Production x402 MCP server on Solana for AI agent trust scoring — free preflight checks + paid cryptographic V5 trust receipts settled in <1s. MCP: `https://intel.twzrd.xyz/mcp`
 
 ### L402
 


### PR DESCRIPTION
TWZRD Agent Intel is a production x402 MCP server running on Solana.

It implements the x402 payment-required flow natively: agents hit the MCP endpoint, receive an HTTP 402 with a payment payload, sign a USDC microtransaction, and get back a signed V5 trust receipt in <1s. No API keys, no accounts.

Live at https://intel.twzrd.xyz/mcp (Streamable-HTTP). Listed on the MCP Registry as io.github.twzrd-sol/twzrd-agent-intel.