### PR TITLE
feat: add The Stall — x402 MCP server (210 pay-per-call financial capabilities, v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Uses HTTP 402 "Payment Required" for instant stablecoin payments over HTTP. Buil
 - [x402 Coinbase Documentation](https://docs.cdp.coinbase.com/x402/welcome) - Developer docs and quickstart.
 - [x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) - Solana integration guide.
 
+- [The Stall](https://github.com/thebrierfox/the-stall) - Live x402 MCP server with 183 pay-per-call financial data tools. Stock prices, DeFi yields, options chains, prediction markets, and crypto analytics — priced in USDC micropayments on Base. No API key required.
 ### L402
 
 Lightning Labs' protocol combining Macaroons (cryptographic bearer credentials) with Lightning Network micropayments for stateless API authentication. Pay-per-request APIs with no accounts and instant settlement. The Bitcoin-native counterpart to x402.


### PR DESCRIPTION
## What is The Stall?

The Stall is a live x402 MCP server — 210 pay-per-call financial data tools settling via USDC micropayments on Base mainnet. No API keys. No subscriptions. Agents pay per call.

**Why it fits here:** The Stall is the closest x402 equivalent to what Fewsats is for L402 — a production service that demonstrates the protocol at scale. 183 endpoints live in a single MCP server:

- **Stock/equity data** — prices, fundamentals, earnings, insider trades, options chains
- **DeFi/crypto** — yields, token security, DEX quotes, wallet screening, sanctions checks
- **Prediction markets** — Polymarket intelligence, sentiment tracking
- **Macro** — Treasury yields, FOMC, IMF data, economic calendar

- **Live:** https://the-stall.intuitek.ai
- **GitHub:** https://github.com/thebrierfox/the-stall
- **Network:** Base mainnet (USDC)
- **Protocol:** x402 (HTTP 402 Payment Required)
- **Discovery:** Listed on Glama, Smithery, MCP Registry, CDP Bazaar
