### PR TITLE
Add xpay x402 facilitator under Crypto payment rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Uses HTTP 402 "Payment Required" for instant stablecoin payments over HTTP. Buil
 
 Independent x402 facilitator for agent-initiated stablecoin payments. Implements the standard x402 `/verify`, `/settle`, and `/supported` endpoints, settling USDC on Base mainnet with no API key, account, or signup. Lets businesses accept agent payments and lets agents pay any x402-enabled endpoint through a single hosted facilitator.
 
-- [xpay Facilitator](https://facilitator.xpay.sh) - Hosted x402 facilitator (verify/settle/supported) on Base mainnet.
-- [xpay](https://xpay.sh) - Documentation and overview.
+- [xpay Facilitator](https://www.xpay.sh/x402-facilitators/xpay/) - Independent x402 facilitator on Base mainnet (verify/settle/supported).
+- [Facilitator endpoint](https://facilitator.xpay.sh) - Hosted facilitator API base URL.
 - [awesome-x402](https://github.com/xpaysh/awesome-x402) - Curated list of x402 protocol resources and implementations.
 
 ### L402

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Maintained by [Bitrefill](https://www.bitrefill.com). Contributions welcome.
   - [MPP (Machine Payments Protocol)](#mpp-machine-payments-protocol)
 - [Crypto payment rails](#crypto-payment-rails)
   - [x402](#x402)
+  - [xpay](#xpay)
   - [L402](#l402)
   - [Fewsats](#fewsats)
 - [Fiat payment rails](#fiat-payment-rails)
@@ -85,6 +86,14 @@ Uses HTTP 402 "Payment Required" for instant stablecoin payments over HTTP. Buil
 - [x402 Specification](https://github.com/coinbase/x402/tree/main/specs) - Full technical specification.
 - [x402 Coinbase Documentation](https://docs.cdp.coinbase.com/x402/welcome) - Developer docs and quickstart.
 - [x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) - Solana integration guide.
+
+### xpay
+
+Independent x402 facilitator for agent-initiated stablecoin payments. Implements the standard x402 `/verify`, `/settle`, and `/supported` endpoints, settling USDC on Base mainnet with no API key, account, or signup. Lets businesses accept agent payments and lets agents pay any x402-enabled endpoint through a single hosted facilitator.
+
+- [xpay Facilitator](https://facilitator.xpay.sh) - Hosted x402 facilitator (verify/settle/supported) on Base mainnet.
+- [xpay](https://xpay.sh) - Documentation and overview.
+- [awesome-x402](https://github.com/xpaysh/awesome-x402) - Curated list of x402 protocol resources and implementations.
 
 ### L402
 


### PR DESCRIPTION
Adds an `### xpay` subsection under **Crypto payment rails**, alongside the existing x402 / L402 / Fewsats entries, and a matching Contents entry.

xpay operates an independent, production [x402](https://www.x402.org/) facilitator on Base mainnet (`https://facilitator.xpay.sh`) implementing the standard `/verify`, `/settle`, and `/supported` endpoints — the same role within the x402 rail that the list already documents.

Links point only to official sources (the facilitator endpoint, the project site, and the curated awesome-x402 resource list), per the contribution guidelines.