### PR TITLE
Add Zero to Crypto payment rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Uses HTTP 402 "Payment Required" for instant stablecoin payments over HTTP. Buil
 - [x402 Specification](https://github.com/coinbase/x402/tree/main/specs) - Full technical specification.
 - [x402 Coinbase Documentation](https://docs.cdp.coinbase.com/x402/welcome) - Developer docs and quickstart.
 - [x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) - Solana integration guide.
+- [Zero](https://zero.xyz) - x402/MPP services layer that lets your AI discover and pay for real services per use at runtime. Ships a CLI, an MCP connector, and a Claude Code plugin. Free to start; most calls cost pennies.
 
 ### L402
 


### PR DESCRIPTION
Zero is an x402/MPP services layer that lets your AI discover and pay for real services per use at runtime, with no accounts or subscriptions. It ships a CLI, an MCP connector, and a Claude Code plugin, and is free to start with most calls costing pennies. It fits the Crypto payment rails (x402) section as an official, production tool built on the x402 rail this list already tracks, listed via its official site zero.xyz.

Disclosure: I work on Zero's go-to-market - happy to tweak the wording, move the section, or close this if it is not a fit.