### PR TITLE
Add SolSigs ProofGuard

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Uses HTTP 402 "Payment Required" for instant stablecoin payments over HTTP. Buil
 - [x402 Coinbase Documentation](https://docs.cdp.coinbase.com/x402/welcome) - Developer docs and quickstart.
 - [x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) - Solana integration guide.
 - [x402 Foundation](https://github.com/x402-foundation/x402) - Neutral governance of the standard under the Linux Foundation, with 22 supporting organizations. [Foundation page](https://linuxfoundation.org/x402foundation/).
+- [SolSigs ProofGuard](https://solsigs.com) - Solana mainnet x402 trust and receipt API for AI agent payments: endpoint trust scores, payment expectation receipts, fulfillment receipts, and refund-evidence packages. Evidence modes distinguish `solsigs_instrumented`, `proofguard_probed`, and `self_attested`. ([GitHub](https://github.com/gra-kir/solsigs-py) | [Docs](https://github.com/gra-kir/solsigs-py/blob/main/docs/proofguard.md))
 
 ### L402
 


### PR DESCRIPTION
Adds SolSigs ProofGuard, a Solana mainnet x402 trust/receipt API for AI agent payments and refund evidence.