### PR TITLE
Add AgentServices — production x402-paid API platform (54 services, 37 MCP tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Uses HTTP 402 "Payment Required" for instant stablecoin payments over HTTP. Buil
 - [x402 Coinbase Documentation](https://docs.cdp.coinbase.com/x402/welcome) - Developer docs and quickstart.
 - [x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) - Solana integration guide.
 - [x402 Foundation](https://github.com/x402-foundation/x402) - Neutral governance of the standard under the Linux Foundation, with 22 supporting organizations. [Foundation page](https://linuxfoundation.org/x402foundation/).
+- [AgentServices](https://agentservices.to) - Production x402-paid API platform with 54 data services, 41 paid endpoints, and an MCP server with 37 tools. Crypto market data, financial APIs, and AI inference — all pay-per-call via USDC on Base.
 
 ### L402
 


### PR DESCRIPTION
## What

Adds [AgentServices](https://agentservices.to) to the **x402** section under Crypto payment rails.

## Why

AgentServices is a production x402-paid API platform — the largest supply-side seller of x402 data APIs. It demonstrates x402 in real-world use with:

- **54 services** across crypto market data, financial APIs, and AI inference
- **41 x402-paid endpoints** settling in USDC on Base
- **MCP server** with 37 tools for agent-native discovery and consumption
- **Listed on the official MCP Registry** (`to.agentservices/agentservices`, v5.3.0)
- Listed on multiple x402 directories (402index.io, paidmcp.dev, awesome-x402)

Agents discover AgentServices via MCP or OpenAPI, receive a 402 challenge, pay in USDC, and get data — no API keys, no accounts, no subscriptions. This is x402 working exactly as specified.

## Where

Added under `### x402` → Crypto payment rails, after the x402 Foundation entry.
