### PR TITLE
Add AsterPay (x402 + MPP facilitator with EUR settlement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Uses HTTP 402 "Payment Required" for instant stablecoin payments over HTTP. Buil
 - [x402 Coinbase Documentation](https://docs.cdp.coinbase.com/x402/welcome) - Developer docs and quickstart.
 - [x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) - Solana integration guide.
 - [x402 Foundation](https://github.com/x402-foundation/x402) - Neutral governance of the standard under the Linux Foundation, with 22 supporting organizations. [Foundation page](https://linuxfoundation.org/x402foundation/).
+- [AsterPay](https://asterpay.io/) - x402 + MPP facilitator with fiat settlement: agents pay USDC on Base/Ethereum/Polygon/Arbitrum/Optimism, merchants receive EUR via SEPA Instant. Includes KYA agent trust scoring (ERC-8004) published on the Intuition knowledge graph.
 
 ### L402
 


### PR DESCRIPTION
Adds AsterPay to the x402 section.

AsterPay is an x402 + MPP facilitator focused on fiat settlement: AI agents pay in USDC (Base, Ethereum, Polygon, Arbitrum, Optimism), and merchants receive EUR in their bank account via SEPA Instant. It also runs KYA (Know Your Agent) trust scoring for ERC-8004 agents, with live assessments published on the Intuition knowledge graph.

Links for verification:
- Site: https://asterpay.io/
- x402 discovery manifest: https://asterpay.io/.well-known/x402.json
- Listed on x402scan and the Coinbase x402 Bazaar
- ERC-8004 agent #16850 on Base

One line added, matching the existing entry format. Happy to adjust wording or placement if you prefer a different section.

Made with [Cursor](https://cursor.com)