### PR TITLE
Add x402 Starter Kit to x402 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Uses HTTP 402 "Payment Required" for instant stablecoin payments over HTTP. Buil
 - [x402 Coinbase Documentation](https://docs.cdp.coinbase.com/x402/welcome) - Developer docs and quickstart.
 - [x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) - Solana integration guide.
 - [x402 Foundation](https://github.com/x402-foundation/x402) - Neutral governance of the standard under the Linux Foundation, with 22 supporting organizations. [Foundation page](https://linuxfoundation.org/x402foundation/).
+- [x402 Starter Kit](https://github.com/StelarDigital/x402-starter-kit) - Single-file, dependency-free x402 v2 server template with Base and Algorand rails and built-in /.well-known/x402 discovery.
 
 ### L402
 


### PR DESCRIPTION
Adds the x402 Starter Kit to the x402 section: a single-file, dependency-free (Python stdlib) x402 v2 server template — spec-correct 402 challenge (header + body), /.well-known/x402 discovery, Base + Algorand rails, MIT licensed. Entry matches existing list style; one line, no other changes.