### PR TITLE
Add ERC-8183 standard and Firmata Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ Practical toolkit for AI agents to make L402 payments. MCP server, CLI, and Pyth
 - [Fewsats MCP Server](https://github.com/fewsats/fewsats-mcp) - MCP server for AI agent payments.
 - [Fewsats Python SDK](https://github.com/Fewsats/L402-python) - L402 payments for AI agents.
 
+ ### Firmata Protocol
+
+  On-chain Know Your Agent (KYA) trust layer that pairs x402 settlement with verified identity (ERC-8004) and conditional     
+  escrow (ERC-8183), so an agent payment is bound to a verified counterparty and a job that completes or refunds. Not a rail; it sits above x402. On Arc (Circle's L1) and Base. Testnet.
+
+  - [firmata.ai](https://firmata.ai) - Protocol overview: the job lifecycle and the three standards it composes.
+  - [meridian-ecosystem](https://github.com/MeridianFinance/meridian-ecosystem) - Public ecosystem index and glossary defining on-chain KYA.
+
 ## Fiat payment rails
 
 Card networks and payment processors building agent-specific primitives: tokenized credentials, sessionless merchant auth, and scoped payment tokens.
@@ -165,6 +173,7 @@ The agent-specific ERCs fall into two groups: session-key and permission standar
 - [ERC-8004: Trustless Agents](https://github.com/ethereum/ERCs/blob/master/ERCS/erc-8004.md) - Draft. On-chain registration of AI agent identity and reputation; interoperates with Solana's Agent Registry. Hub: [8004.org](https://8004.org).
 - [ERC-8126: AI Agent Verification](https://github.com/ethereum/ERCs/blob/master/ERCS/erc-8126.md) - Draft. A risk-scoring and verification layer for registered agents.
 - [ERC-8196: AI Agent Authenticated Wallet](https://github.com/ethereum/ERCs/blob/master/ERCS/erc-8196.md) - Draft. Policy-bound transaction execution and verifiable credential delegation for autonomous agents; builds on ERC-8004 and ERC-8126. Discussion: [Fellowship of Ethereum Magicians](https://ethereum-magicians.org/t/erc-8196-ai-agent-authenticated-wallet/27987).
+- [ERC-8183: Agentic Commerce](https://github.com/ethereum/ERCs/b  lob/master/ERCS/erc-8183.md) - Draft. A "Job" escrow standard for agent-to-agent commerce: an escrowed budget with four states (Open, Funded, Submitted, Terminal) and an evaluator who marks completion, releasing funds to the provider or refunding the client. Discussion: [Fellowship of Ethereum Magicians](https://ethereum-magicians.org/t/erc-8183-agentic-commerce/27902).
 
 ### Solana
 


### PR DESCRIPTION
Two additions:
1. ERC-8183 (Agentic Commerce) added under Ethereum standards.  A Job/escrow standard for agent-to-agent commerce (Open, Funded, Submitted, Terminal, plus an evaluator), a natural companion to the ERC-8004/8126/8196 family already listed. 
Official EIP:      
https://eips.ethereum.org/EIPS/eip-8183
2. Firmata Protocol under Crypto payment rails. An on-chain trust layer that pairs x402 with ERC-8004 identity and ERC-8183 escrow (not a rail, it sits above x402). Official sources: firmata.ai and github.com/MeridianFinance/meridian-ecosystem.    
Testnet on Arc and Base.

Happy to adjust placement or wording.