### PR TITLE
Add PipRail to Crypto payment rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Maintained by [Bitrefill](https://www.bitrefill.com). Contributions welcome.
   - [x402](#x402)
   - [L402](#l402)
   - [Fewsats](#fewsats)
+  - [PipRail](#piprail)
 - [Fiat payment rails](#fiat-payment-rails)
   - [Stripe](#stripe)
   - [Visa](#visa)
@@ -109,6 +110,15 @@ Practical toolkit for AI agents to make L402 payments. MCP server, CLI, and Pyth
 
 - [Fewsats MCP Server](https://github.com/fewsats/fewsats-mcp) - MCP server for AI agent payments.
 - [Fewsats Python SDK](https://github.com/Fewsats/L402-python) - L402 payments for AI agents.
+
+### PipRail
+
+Open source TypeScript SDK for x402 payments across 29 chains, letting a server charge for a request and an AI agent pay for one. Verification runs against the developer's own RPC node, with no backend and no fee in between. Ships an MCP server that gives any MCP client a budget-bound wallet.
+
+- [PipRail GitHub Repository](https://github.com/piprail/piprail) - MIT-licensed SDK and MCP server.
+- [PipRail Documentation](https://docs.piprail.com) - Developer docs and quickstart.
+- [Supported chains](https://docs.piprail.com/chains/overview/) - 29 chains across 10 families, with the per-chain verification notes.
+- [Facilitator coverage](https://piprail.com/facilitators) - Which keyless x402 facilitators settle on which networks, each verified by a settled mainnet transaction.
 
 ## Fiat payment rails
 


### PR DESCRIPTION
Adds PipRail under **Crypto payment rails**, in the same shape as the existing Fewsats entry: a maintained open source toolkit for one of the rails already covered, rather than a new protocol.

PipRail is an MIT-licensed TypeScript SDK for x402. A server can charge for a request and an AI agent can pay for one, across 29 chains in 10 families. Verification runs against the developer's own RPC node, so there is no backend and no fee in between. It also ships an MCP server that hands any MCP client a budget-bound wallet.

I maintain it, so these are official sources per CONTRIBUTING.md.

- Repo: https://github.com/piprail/piprail
- Docs: https://docs.piprail.com

**On the link check:** every link added returns 200. I deliberately left out the npm package pages (npm serves 403 to automated checkers) and our live 402 demo endpoint (it returns `402 Payment Required` by design, which a link checker reads as a failure).

Changes are the section itself plus one matching line in Contents. Happy to reshape or trim it if you would rather it sat somewhere else.
